### PR TITLE
Handle no error message

### DIFF
--- a/src/Backend/WacomDevice.vala
+++ b/src/Backend/WacomDevice.vala
@@ -51,7 +51,7 @@ public class Wacom.Backend.WacomDevice : GLib.Object {
         var error = new Wacom.Error ();
         wacom_device = wacom_db.get_device_from_path (device.device_file, Wacom.FallbackFlags.NONE, error);
         if (wacom_device == null) {
-            throw new WacomException.LIBWACOM_ERROR (error.get_message ());
+            throw new WacomException.LIBWACOM_ERROR (error.get_message () ?? "");
         }
     }
 


### PR DESCRIPTION
Fixes: #16
In my case the error did have a error code (`Wacom.ErrorCode.UNKNOWN_MODEL`), but the error message was null, which triggered a crash.