### PR TITLE
Support for Tablets without physical buttons

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -185,6 +185,16 @@ public class Wacom.Plug : Switchboard.Plug {
             }
         }
 
+        // Devices with no physical buttons on the tablet do not have DeviceType.PAD
+        // In this case, select the first TABLET device
+        foreach (var device in devices.keys) {
+            if (Backend.Device.DeviceType.TABLET in device.dev_type) {
+                empty_stack.visible_child_name = "main_view";
+                tablet_view.set_device (devices[device]);
+                return;
+            }
+        }
+
         empty_stack.visible_child_name = "no_tablets";
     }
 


### PR DESCRIPTION
Devices with physical buttons export at least one device with `DeviceType.PAD`, which results in their detection in `update_current_page`. Devices without physical buttons (such as my Wacom One tablets) only exports `DeviceType.TABLET`. 

If no device with `DeviceType.PAD` is found, I propose to use the first `DeviceType.TABLET` found. This makes `TabletView` work fine on my device. I can set left/right handed mode and positive/relative tracking.

Partly addresses issue #20 , but no stylus is found yet. 