### PR TITLE
Add MainPage

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,4 +1,4 @@
 src/Views/StylusView.vala
 src/Views/TabletView.vala
+src/MainPage.vala
 src/Plug.vala
-

--- a/src/MainPage.vala
+++ b/src/MainPage.vala
@@ -1,0 +1,149 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ * SPDX-FileCopyrightText: 2019-2024 elementary, Inc. (https://elementary.io)
+ */
+
+public class Wacom.MainPage : Granite.SimpleSettingsPage {
+    private Backend.DeviceManager device_manager;
+    private Backend.WacomTool? last_stylus = null;
+
+    private Backend.WacomToolMap tool_map;
+    private Gee.HashMap<Backend.Device, Backend.WacomDevice>? devices;
+
+    private Granite.Widgets.AlertView placeholder;
+    private Gtk.Box main_box;
+    private Gtk.Stack stack;
+    private StylusView stylus_view;
+    private TabletView tablet_view;
+
+    public MainPage () {
+        Object (
+            title: _("Wacom"),
+            icon_name: "input-tablet"
+        );
+    }
+
+    construct {
+        devices = new Gee.HashMap<Backend.Device, Backend.WacomDevice> ();
+        tool_map = Backend.WacomToolMap.get_default ();
+
+        placeholder = new Granite.Widgets.AlertView (
+            _("No Tablets Available"),
+            _("Please ensure your tablet is connected and switched on"),
+            ""
+        );
+        placeholder.get_style_context ().remove_class ("view");
+        placeholder.show_all ();
+
+        tablet_view = new TabletView ();
+        stylus_view = new StylusView ();
+
+        main_box = new Gtk.Box (VERTICAL, 24);
+        main_box.add (tablet_view);
+        main_box.add (stylus_view);
+
+        stack = new Gtk.Stack ();
+        stack.add (main_box);
+        stack.add (placeholder);
+
+        content_area.add (stack);
+
+        show_all ();
+
+        device_manager = Backend.DeviceManager.get_default ();
+        device_manager.device_added.connect (on_device_added);
+        device_manager.device_removed.connect (on_device_removed);
+
+        foreach (var device in device_manager.list_devices (TABLET)) {
+            add_known_device (device);
+        }
+
+        stack.event.connect (update_current_tool);
+
+        update_current_page ();
+    }
+
+    private void on_device_added (Backend.Device device) {
+        add_known_device (device);
+        update_current_page ();
+    }
+
+    private void on_device_removed (Backend.Device device) {
+        devices.unset (device);
+        update_current_page ();
+    }
+
+    private void add_known_device (Backend.Device d) {
+        if (!(Backend.Device.DeviceType.TABLET in d.dev_type)) {
+            return;
+        }
+
+        if (Backend.Device.DeviceType.TOUCHSCREEN in d.dev_type ||
+            Backend.Device.DeviceType.TOUCHPAD in d.dev_type ||
+            Backend.Device.DeviceType.PAD in d.dev_type) {
+            return;
+        }
+
+        try {
+            devices[d] = new Backend.WacomDevice (d);
+        } catch (WacomException e) {
+            warning ("Error initializing Wacom device: %s", e.message);
+            return;
+        }
+
+        var tools = tool_map.list_tools (devices[d]);
+        if (tools.size > 0) {
+            stylus_view.set_device (tools[0]);
+        }
+     }
+
+    private void update_current_page () {
+        foreach (var device in devices.keys) {
+            stack.visible_child = main_box;
+            tablet_view.set_device (devices[device]);
+            return;
+        }
+
+        stack.visible_child = placeholder;
+    }
+
+    private bool update_current_tool (Gdk.Event event) {
+        if (event.get_event_type () == Gdk.EventType.MOTION_NOTIFY) {
+            var tool = event.get_device_tool ();
+            if (tool == null) {
+                return Gdk.EVENT_PROPAGATE;
+            }
+
+            var device = device_manager.lookup_gdk_device (event.get_source_device ());
+            if (device == null) {
+                return Gdk.EVENT_PROPAGATE;
+            }
+
+            var wacom_device = devices[device];
+            if (wacom_device == null) {
+                return Gdk.EVENT_PROPAGATE;
+            }
+
+            var serial = tool.get_serial ();
+
+            var stylus = tool_map.lookup_tool (wacom_device, serial);
+            if (stylus == null) {
+                var id = tool.get_hardware_id ();
+                try {
+                    stylus = new Backend.WacomTool (serial, id, wacom_device);
+                } catch (GLib.Error e) {
+                    return Gdk.EVENT_PROPAGATE;
+                }
+            }
+
+            tool_map.add_relation (wacom_device, stylus);
+            if (stylus != last_stylus) {
+                stylus_view.set_device (stylus);
+            }
+
+            last_stylus = stylus;
+        }
+
+        return Gdk.EVENT_PROPAGATE;
+    }
+}

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -1,37 +1,10 @@
 /*
- * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ * SPDX-FileCopyrightText: 2019-2024 elementary, Inc. (https://elementary.io)
  */
 
 public class Wacom.Plug : Switchboard.Plug {
-
-    private Gtk.Stack main_stack;
-    private Gtk.ScrolledWindow scrolled;
-    private Gtk.Stack empty_stack;
-
-    private StylusView stylus_view;
-    private TabletView tablet_view;
-
-    private Backend.DeviceManager device_manager;
-
-    private Gee.HashMap<Backend.Device, Backend.WacomDevice>? devices = null;
-
-    private Backend.WacomTool? last_stylus = null;
-    private Backend.WacomToolMap tool_map;
+    private MainPage main_page;
 
     public Plug () {
         GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
@@ -53,151 +26,11 @@ public class Wacom.Plug : Switchboard.Plug {
     }
 
     public override Gtk.Widget get_widget () {
-        if (empty_stack == null) {
-
-            if (devices == null) {
-                devices = new Gee.HashMap<Backend.Device, Backend.WacomDevice> ();
-            } else {
-                devices.clear ();
-            }
-
-            tool_map = Backend.WacomToolMap.get_default ();
-
-            stylus_view = new StylusView ();
-            tablet_view = new TabletView ();
-
-            main_stack = new Gtk.Stack ();
-            main_stack.margin = 12;
-            main_stack.add_titled (stylus_view, "stylus", _("Stylus"));
-            main_stack.add_titled (tablet_view, "tablet", _("Tablet"));
-
-            var switcher = new Gtk.StackSwitcher ();
-            switcher.halign = Gtk.Align.CENTER;
-            switcher.homogeneous = true;
-            switcher.margin = 12;
-            switcher.stack = main_stack;
-
-            var main_grid = new Gtk.Grid ();
-            main_grid.halign = Gtk.Align.CENTER;
-            main_grid.attach (switcher, 0, 0);
-            main_grid.attach (main_stack, 0, 1);
-
-            scrolled = new Gtk.ScrolledWindow (null, null);
-            scrolled.add (main_grid);
-            scrolled.show_all ();
-
-            var alert_view = new Granite.Widgets.AlertView (
-                _("No Tablets Available"),
-                _("Please ensure your tablet is connected and switched on"),
-                "input-tablet"
-            );
-
-            empty_stack = new Gtk.Stack ();
-            empty_stack.add_named (scrolled, "main_view");
-            empty_stack.add_named (alert_view, "no_tablets");
-
-            empty_stack.show_all ();
-
-            empty_stack.visible_child_name = "no_tablets";
-
-            empty_stack.event.connect (update_current_tool);
-
-            device_manager = Backend.DeviceManager.get_default ();
-            device_manager.device_added.connect (on_device_added);
-            device_manager.device_removed.connect (on_device_removed);
-
-            foreach (var device in device_manager.list_devices (Backend.Device.DeviceType.TABLET)) {
-                add_known_device (device);
-            }
-
-            update_current_page ();
+        if (main_page == null) {
+            main_page = new MainPage ();
         }
 
-        return empty_stack;
-    }
-
-    private bool update_current_tool (Gdk.Event event) {
-        if (event.get_event_type () == Gdk.EventType.MOTION_NOTIFY) {
-            var tool = event.get_device_tool ();
-            if (tool == null) {
-                return Gdk.EVENT_PROPAGATE;
-            }
-
-            var device = device_manager.lookup_gdk_device (event.get_source_device ());
-            if (device == null) {
-                return Gdk.EVENT_PROPAGATE;
-            }
-
-            var wacom_device = devices[device];
-            if (wacom_device == null) {
-                return Gdk.EVENT_PROPAGATE;
-            }
-
-            var serial = tool.get_serial ();
-
-            var stylus = tool_map.lookup_tool (wacom_device, serial);
-            if (stylus == null) {
-                var id = tool.get_hardware_id ();
-                try {
-                    stylus = new Backend.WacomTool (serial, id, wacom_device);
-                } catch (GLib.Error e) {
-                    return Gdk.EVENT_PROPAGATE;
-                }
-            }
-
-            tool_map.add_relation (wacom_device, stylus);
-            if (stylus != last_stylus) {
-                stylus_view.set_device (stylus);
-            }
-
-            last_stylus = stylus;
-        }
-
-        return Gdk.EVENT_PROPAGATE;
-    }
-
-    private void add_known_device (Backend.Device d) {
-        if (!(Backend.Device.DeviceType.TABLET in d.dev_type)) {
-            return;
-        }
-
-        if (Backend.Device.DeviceType.TOUCHSCREEN in d.dev_type ||
-            Backend.Device.DeviceType.TOUCHPAD in d.dev_type ||
-            Backend.Device.DeviceType.PAD in d.dev_type) {
-            return;
-        }
-
-        try {
-            devices[d] = new Backend.WacomDevice (d);
-        } catch (WacomException e) {
-            warning ("Error initializing Wacom device: %s", e.message);
-            return;
-        }
-
-        var tools = tool_map.list_tools (devices[d]);
-        if (tools.size > 0) {
-            stylus_view.set_device (tools[0]);
-        }
-     }
-
-    private void update_current_page () {
-        foreach (var device in devices.keys) {
-            empty_stack.visible_child_name = "main_view";
-            tablet_view.set_device (devices[device]);
-            return;
-        }
-
-        empty_stack.visible_child_name = "no_tablets";
-    }
-
-    private void on_device_added (Backend.Device device) {
-        add_known_device (device);
-        update_current_page ();
-    }
-
-    private void on_device_removed (Backend.Device device) {
-        devices.unset (device);
-        update_current_page ();
+        return main_page;
     }
 
     public override void shown () {
@@ -221,8 +54,5 @@ public class Wacom.Plug : Switchboard.Plug {
 
 public Switchboard.Plug get_plug (Module module) {
     debug ("Activating Wacom plug");
-
-    var plug = new Wacom.Plug ();
-
-    return plug;
+    return new Wacom.Plug ();
 }

--- a/src/Views/StylusView.vala
+++ b/src/Views/StylusView.vala
@@ -43,7 +43,7 @@ public class Wacom.StylusView : Gtk.Stack {
         var no_stylus_view = new Granite.Widgets.AlertView (
             _("No Stylus Detected"),
             _("Please move your stylus close to the tablet"),
-            "input-tablet"
+            ""
         );
         no_stylus_view.get_style_context ().remove_class (Gtk.STYLE_CLASS_VIEW);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,6 +10,7 @@ plug_files = files(
     'Views/TabletView.vala',
     'Widgets/DrawingArea.vala',
     'Widgets/SettingLabel.vala',
+    'MainPage.vala',
     'Plug.vala',
     'Utils.vala'
 )


### PR DESCRIPTION
Introduce a MainPage class that's a SimpleSettingsPage subclass. This will be a Switchboard.SettingsPage in GTK 4 which gives us some free stuff like clamping.

Puts all settings on a single page since there's not that many settings.

This doesn't seek to solve some of the weirdness with how devices are managed currently. All that stuff is 1:1 from master

![Screenshot from 2024-02-27 11 32 50](https://github.com/elementary/switchboard-plug-wacom/assets/7277719/f759bc54-ee47-4188-8c66-8722182d1dc8)
