### PR TITLE
MainPage: associate stylus from tabletview devicekey

### DIFF
--- a/src/Backend/WacomToolMap.vala
+++ b/src/Backend/WacomToolMap.vala
@@ -147,14 +147,9 @@ public class Wacom.Backend.WacomToolMap : GLib.Object {
         return "%llx".printf (serial);
     }
 
-    public void add_relation (Gdk.Device gdk_device, WacomTool tool) {
+    public void add_relation (string device_key, WacomTool tool) {
         string tool_key;
         bool tools_changed = false, tablets_changed = false;
-
-        var device_key = "%s:%s".printf (
-            gdk_device.get_vendor_id (),
-            gdk_device.get_product_id ()
-        );
 
         var serial = tool.serial;
 
@@ -222,23 +217,12 @@ public class Wacom.Backend.WacomToolMap : GLib.Object {
         tools.set_string (tool_key, KEY_TOOL_ID, str);
     }
 
-    public WacomTool? lookup_tool (Gdk.Device device, uint64 serial) {
-        string key;
-        WacomTool? tool = null;
-
+    public WacomTool? lookup_tool (uint64 serial, string device_key) {
         if (serial == 0) {
-            key = "%s:%s".printf (
-                device.get_vendor_id (),
-                device.get_product_id ()
-            );
-
-            tool = no_serial_tool_map[key];
+            return no_serial_tool_map[device_key];
         } else {
-            key = get_tool_key (serial);
-            tool = tool_map[key];
+            return tool_map[get_tool_key (serial)];
         }
-
-        return tool;
     }
 
     public Gee.ArrayList<WacomTool> list_tools (Backend.Device device) {

--- a/src/MainPage.vala
+++ b/src/MainPage.vala
@@ -106,7 +106,10 @@ public class Wacom.MainPage : Granite.SimpleSettingsPage {
     private void update_current_page () {
         foreach (var device in device_manager.list_devices (TABLET)) {
             stack.visible_child = main_box;
-            tablet_view.set_device (device);
+            tablet_view.device_key = "%s:%s".printf (
+                device.vendor_id,
+                device.product_id
+            );
             return;
         }
 
@@ -115,20 +118,19 @@ public class Wacom.MainPage : Granite.SimpleSettingsPage {
 
     private void on_stylus (double object, double p0) {
         var event = Gtk.get_current_event ();
-        var gdk_device = event.get_source_device ();
         var tool = event.get_device_tool ();
 
-        if (gdk_device == null || tool == null) {
-            critical ("Gdk.Device or DeviceTool not found");
+        if (tool == null) {
+            critical ("DeviceTool not found");
             return;
         }
 
         var serial = tool.get_serial ();
 
-        var wacom_tool = tool_map.lookup_tool (gdk_device, serial);
+        var wacom_tool = tool_map.lookup_tool (serial, tablet_view.device_key);
         if (wacom_tool == null) {
             wacom_tool = new Backend.WacomTool (serial, tool.get_hardware_id ());
-            tool_map.add_relation (gdk_device, wacom_tool);
+            tool_map.add_relation (tablet_view.device_key, wacom_tool);
         }
 
         if (wacom_tool != last_stylus) {

--- a/src/Views/TabletView.vala
+++ b/src/Views/TabletView.vala
@@ -19,7 +19,24 @@
 
 public class Wacom.TabletView : Gtk.Grid {
     private const string WACOM_TABLET_SCHEMA = "org.gnome.desktop.peripherals.tablet";
-    private const string WACOM_SETTINGS_BASE = "/org/gnome/desktop/peripherals/tablets/%s:%s/";
+    private const string WACOM_SETTINGS_BASE = "/org/gnome/desktop/peripherals/tablets/%s/";
+
+    private string _device_key;
+    public string device_key {
+        get {
+            return _device_key;
+        }
+
+        set {
+            _device_key = value;
+
+            var path = WACOM_SETTINGS_BASE.printf (device_key);
+
+            settings = new Settings.with_path (WACOM_TABLET_SCHEMA, path);
+            settings.bind ("mapping", tracking_mode_combo, "active-id", SettingsBindFlags.DEFAULT);
+            settings.bind ("left-handed", left_handed_switch, "active", SettingsBindFlags.DEFAULT);
+        }
+    }
 
     private GLib.Settings settings;
 
@@ -52,13 +69,5 @@ public class Wacom.TabletView : Gtk.Grid {
         attach (tracking_mode_combo, 1, 0);
         attach (left_handed_label, 0, 1);
         attach (left_handed_switch, 1, 1);
-    }
-
-    public void set_device (Backend.Device dev) {
-        var path = WACOM_SETTINGS_BASE.printf (dev.vendor_id, dev.product_id);
-
-        settings = new Settings.with_path (WACOM_TABLET_SCHEMA, path);
-        settings.bind ("mapping", tracking_mode_combo, "active-id", SettingsBindFlags.DEFAULT);
-        settings.bind ("left-handed", left_handed_switch, "active", SettingsBindFlags.DEFAULT);
     }
 }


### PR DESCRIPTION
There's no source device in GTK 4, so get the device key from the current tablet view