### PR TITLE
Add check for stylus detection

### DIFF
--- a/data/wacom.metainfo.xml.in
+++ b/data/wacom.metainfo.xml.in
@@ -31,6 +31,14 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
+    <release version="8.0.1" date="2024-12-17" urgency="medium">
+      <description>
+        <ul>
+          <li>A fix for a crush that occured when stylus is not detected by libwacom</li>
+        </ul>
+      </description>
+    </release>
+
     <release version="8.0.0" date="2024-07-02" urgency="medium">
       <description>
         <p>A Big Redesign!</p>

--- a/data/wacom.metainfo.xml.in
+++ b/data/wacom.metainfo.xml.in
@@ -33,10 +33,13 @@
   <releases>
     <release version="8.0.1" date="2024-12-17" urgency="medium">
       <description>
-        <p>Updated translations</p>
+        <p>Updates:</p>
+        <ul>
+          <li>Updated translations</li>
+        </ul>
       </description>
       <issues>
-        <issue url="https://github.com/elementary/switchboard-plug-wacom/issues/69">A fix for a crush of Settings that occured when stylus is not detected by libwacom.</issue>
+        <issue url="https://github.com/elementary/switchboard-plug-wacom/issues/69">Clicking on the Wacom plug crushes Settings, because stylus is not detected by libwacom</issue>
       </issues>
     </release>
 

--- a/data/wacom.metainfo.xml.in
+++ b/data/wacom.metainfo.xml.in
@@ -33,10 +33,11 @@
   <releases>
     <release version="8.0.1" date="2024-12-17" urgency="medium">
       <description>
-        <ul>
-          <li>A fix for a crush that occured when stylus is not detected by libwacom</li>
-        </ul>
+        <p>Updated translations</p>
       </description>
+      <issues>
+        <issue url="https://github.com/elementary/switchboard-plug-wacom/issues/69">A fix for a crush of Settings that occured when stylus is not detected by libwacom.</issue>
+      </issues>
     </release>
 
     <release version="8.0.0" date="2024-07-02" urgency="medium">

--- a/src/MainPage.vala
+++ b/src/MainPage.vala
@@ -89,7 +89,8 @@ public class Wacom.MainPage : Switchboard.SettingsPage {
         }
 
         var tools = tool_map.list_tools (d);
-        if (tools.size > 0) {
+        debug ("Tools map size: %d", tools.size);
+        if (tools.size > 0 && stylus_view.is_stylus_supported (tools[0])) {
             stylus_view.set_device (tools[0]);
             stylus_stack.visible_child = stylus_view;
         }
@@ -124,8 +125,10 @@ public class Wacom.MainPage : Switchboard.SettingsPage {
         }
 
         if (wacom_tool != last_stylus) {
-            stylus_view.set_device (wacom_tool);
-            stylus_stack.visible_child = stylus_view;
+            if (stylus_view.is_stylus_supported (wacom_tool)) {
+                stylus_view.set_device (wacom_tool);
+                stylus_stack.visible_child = stylus_view;
+            }
         }
 
         last_stylus = wacom_tool;

--- a/src/Views/StylusView.vala
+++ b/src/Views/StylusView.vala
@@ -31,6 +31,13 @@ public class Wacom.StylusView : Gtk.Box {
         append (stylus_box);
     }
 
+    public bool is_stylus_supported (Backend.WacomTool wacom_tool) {
+        debug ("%d", (int) wacom_tool.id);
+        unowned var stylus = wacom_db.get_stylus_for_id ((int) wacom_tool.id);
+        if (stylus == null) return false;
+        return true;
+    }
+
     public void set_device (Backend.WacomTool wacom_tool) {
         while (stylus_box.get_first_child () != null) {
             stylus_box.remove (stylus_box.get_first_child ());

--- a/src/Views/StylusView.vala
+++ b/src/Views/StylusView.vala
@@ -32,10 +32,8 @@ public class Wacom.StylusView : Gtk.Box {
     }
 
     public bool is_stylus_supported (Backend.WacomTool wacom_tool) {
-        debug ("%d", (int) wacom_tool.id);
         unowned var stylus = wacom_db.get_stylus_for_id ((int) wacom_tool.id);
-        if (stylus == null) return false;
-        return true;
+        return stylus != null;
     }
 
     public void set_device (Backend.WacomTool wacom_tool) {


### PR DESCRIPTION
This should prevent a crash of Settings, when Stylus in `null`.