### PR TITLE
Fix some build warnings

### DIFF
--- a/src/Backend/WacomToolMap.vala
+++ b/src/Backend/WacomToolMap.vala
@@ -225,7 +225,7 @@ public class Wacom.Backend.WacomToolMap : GLib.Object {
         }
     }
 
-    public Gee.ArrayList<WacomTool> list_tools (Backend.Device device) {
+    public Gee.ArrayList<WacomTool> list_tools (Backend.Device device) throws WacomException {
         var styli = new Gee.ArrayList<WacomTool> ();
 
         var key = "%s:%s".printf (device.vendor_id, device.product_id);

--- a/src/MainPage.vala
+++ b/src/MainPage.vala
@@ -92,7 +92,7 @@ public class Wacom.MainPage : Switchboard.SettingsPage {
         try {
             tools = tool_map.list_tools (d);
         } catch (WacomException e) {
-            warning (e.message);
+            warning ("Failed to list tools: %s", e.message);
             return;
         }
 

--- a/src/MainPage.vala
+++ b/src/MainPage.vala
@@ -88,7 +88,14 @@ public class Wacom.MainPage : Switchboard.SettingsPage {
             return;
         }
 
-        var tools = tool_map.list_tools (d);
+        Gee.ArrayList<Backend.WacomTool> tools;
+        try {
+            tools = tool_map.list_tools (d);
+        } catch (WacomException e) {
+            warning (e.message);
+            return;
+        }
+
         if (tools.size > 0) {
             stylus_view.set_device (tools[0]);
             stylus_stack.visible_child = stylus_view;


### PR DESCRIPTION
### After
```
user@VirtualBox-36929c8d:~/work/switchboard-plug-wacom$ ninja -C builddir/ install
ninja: Entering directory `builddir/'
[1/15] Compiling Vala source ../src/Backend/Device.vala ../src/Backend/DeviceManager.vala ../src/Backend/DeviceManage...w.vala ../src/Views/TabletView.vala ../src/Widgets/DrawingArea.vala ../src/MainPage.vala ../src/Plug.vala Config.vala
../src/Views/StylusView.vala:107.32-107.47: warning: `Gtk.ComboBoxText' has been deprecated since 4.10
  107 |         var button_combo = new Gtk.ComboBoxText () {
      |                                ^~~~~~~~~~~~~~~~     
../src/Views/StylusView.vala:107.13-107.24: warning: `Gtk.ComboBoxText' has been deprecated since 4.10
  107 |         var button_combo = new Gtk.ComboBoxText () {
      |             ^~~~~~~~~~~~                            
../src/Views/TabletView.vala:43.5-43.48: warning: `Gtk.ComboBoxText' has been deprecated since 4.10
   43 |     private Gtk.ComboBoxText tracking_mode_combo;
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
../src/Views/TabletView.vala:50.35-50.50: warning: `Gtk.ComboBoxText' has been deprecated since 4.10
   50 |         tracking_mode_combo = new Gtk.ComboBoxText ();
      |                                   ^~~~~~~~~~~~~~~~    
Compilation succeeded - 4 warning(s)
```

### Before
Latest main (06e3765865d5b160a1d0af614385415f54801775)

```
user@VirtualBox-36929c8d:~/work/switchboard-plug-wacom$ ninja -C builddir/ install
ninja: Entering directory `builddir/'
[1/15] Compiling Vala source ../src/Backend/Device.vala ../src/Backend/DeviceManager.vala ../src/Backend/DeviceManage...w.vala ../src/Views/TabletView.vala ../src/Widgets/DrawingArea.vala ../src/MainPage.vala ../src/Plug.vala Config.vala
../src/Backend/DeviceManagerWayland.vala:100.17-100.32: note: Assignment: Unsafe conversion from `int' to `Wacom.Backend.Device.DeviceType'
  100 |                 type |= (1 << i);
      |                 ^~~~~~~~~~~~~~~~ 
../src/Backend/DeviceManagerWayland.vala:152.25-152.68: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  152 |         var node_path = (device as Gdk.Wayland.Device).get_node_path ();
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
../src/Backend/WacomToolMap.vala:247.21-247.88: warning: unhandled error `WacomException'
  247 |                     throw new WacomException.LIBWACOM_ERROR (error.get_message () ?? "");
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
../src/Views/StylusView.vala:107.32-107.47: warning: `Gtk.ComboBoxText' has been deprecated since 4.10
  107 |         var button_combo = new Gtk.ComboBoxText () {
      |                                ^~~~~~~~~~~~~~~~     
../src/Views/StylusView.vala:107.13-107.24: warning: `Gtk.ComboBoxText' has been deprecated since 4.10
  107 |         var button_combo = new Gtk.ComboBoxText () {
      |             ^~~~~~~~~~~~                            
../src/Views/TabletView.vala:43.5-43.48: warning: `Gtk.ComboBoxText' has been deprecated since 4.10
   43 |     private Gtk.ComboBoxText tracking_mode_combo;
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
../src/Views/TabletView.vala:50.35-50.50: warning: `Gtk.ComboBoxText' has been deprecated since 4.10
   50 |         tracking_mode_combo = new Gtk.ComboBoxText ();
      |                                   ^~~~~~~~~~~~~~~~    
Compilation succeeded - 6 warning(s)
```