### PR TITLE
Rename as Pen & Drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wacom Settings
+# Pen & Drawing Settings
 [![Translation status](https://l10n.elementaryos.org/widget/settings/wacom/svg-badge.svg)](https://l10n.elementaryos.org/engage/settings/)
 
 ![screenshot](data/screenshot.png?raw=true)

--- a/src/MainPage.vala
+++ b/src/MainPage.vala
@@ -19,7 +19,7 @@ public class Wacom.MainPage : Switchboard.SettingsPage {
 
     public MainPage () {
         Object (
-            title: _("Wacom"),
+            title: _("Pen & Drawing"),
             icon: new ThemedIcon ("input-tablet")
         );
     }

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -18,8 +18,8 @@ public class Wacom.Plug : Switchboard.Plug {
         Object (
             category: Category.HARDWARE,
             code_name: "pantheon-wacom",
-            display_name: _("Wacom"),
-            description: _("Configure Wacom tablet"),
+            display_name: _("Pen & Drawing"),
+            description: _("Configure digitizer pens and drawing tablets"),
             icon: "input-tablet",
             supported_settings: settings
         );


### PR DESCRIPTION
These settings also apply to devices like the StarLite which work with a pen and don't have an external tablet

Context:
<img width="881" height="621" alt="Screenshot from 2026-01-20 09 00 58" src="https://github.com/user-attachments/assets/1e615cbc-eb05-4341-94be-18fbd42ea7e4" />
